### PR TITLE
Remove dir suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Remove "_dir" or "-dir" prefix from input flag and variables/arguments names
+
 ## [1.0.0] - 2023-08-29
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN pip install --no-cache-dir /src/scraper \
 RUN mkdir -p /output
 WORKDIR /output
 
-ENV BUILD_DIR=/tmp
-ENV OUTPUT_DIR=/output
-ENV ZIMUI_DIST_DIR=/src/zimui
+ENV FCC_BUILD=/tmp
+ENV FCC_OUTPUT=/output
+ENV FCC_ZIMUI_DIST=/src/zimui
 
 ENTRYPOINT ["fcc2zim"]

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -85,7 +85,7 @@ fix-ruff = "inv fix-ruff --args '{args}'"
 fixall = "inv fixall --args '{args}'"
 
 [tool.hatch.envs.check]
-features = ["scripts", "check"]
+features = ["scripts", "check", "test"]
 
 [tool.hatch.envs.check.scripts]
 pyright = "inv check-pyright --args '{args}'"

--- a/scraper/src/fcc2zim/build.py
+++ b/scraper/src/fcc2zim/build.py
@@ -7,7 +7,7 @@ from zimscraperlib.zim import Creator
 from fcc2zim.constants import Global
 
 
-def build_curriculum_redirects(curriculum_dist_dir: Path, fcc_lang: str):
+def build_curriculum_redirects(curriculum_dist: Path, fcc_lang: str):
     """
     Build the list of redirects from challenge URL to Vite hash URL
 
@@ -15,7 +15,7 @@ def build_curriculum_redirects(curriculum_dist_dir: Path, fcc_lang: str):
     need an URL for each challenge for the zim search to work.
     This builds the list of redirect needed fron the challenge URL to Vite hash URL.
     """
-    index_json_path = curriculum_dist_dir.joinpath("curriculum", fcc_lang, "index.json")
+    index_json_path = curriculum_dist.joinpath("curriculum", fcc_lang, "index.json")
     with open(index_json_path) as course_index_str:
         superblock_dict = json.load(course_index_str)[fcc_lang]
 
@@ -24,7 +24,7 @@ def build_curriculum_redirects(curriculum_dist_dir: Path, fcc_lang: str):
         course_list = superblock_dict[superblock]
         for course in course_list:
             meta_json_path = Path(
-                curriculum_dist_dir,
+                curriculum_dist,
                 "curriculum",
                 fcc_lang,
                 superblock,
@@ -42,31 +42,31 @@ def build_curriculum_redirects(curriculum_dist_dir: Path, fcc_lang: str):
 
 
 def build_command(
-    zimui_dist_dir: Path,
+    zimui_dist: Path,
     fcc_lang: str,
     creator: Creator,
-    curriculum_dist_dir: Path,
+    curriculum_dist: Path,
 ):
     Global.logger.info("Scraper: build phase starting")
 
     # Add zimui files
-    for file in zimui_dist_dir.rglob("*"):
+    for file in zimui_dist.rglob("*"):
         if file.is_dir():
             continue
-        path = str(Path(file).relative_to(zimui_dist_dir))
+        path = str(Path(file).relative_to(zimui_dist))
         Global.logger.debug(f"Adding {path} to ZIM")
         creator.add_item_for(path, fpath=file)
 
     # Add prebuild generated curriculum file
-    for file in curriculum_dist_dir.rglob("*"):
+    for file in curriculum_dist.rglob("*"):
         if file.is_dir():
             continue
-        path = str(Path("fcc").joinpath(Path(file).relative_to(curriculum_dist_dir)))
+        path = str(Path("fcc").joinpath(Path(file).relative_to(curriculum_dist)))
         Global.logger.debug(f"Adding {path} to ZIM")
         creator.add_item_for(path, fpath=file)
 
     for redir_slug, redir_title in build_curriculum_redirects(
-        curriculum_dist_dir=curriculum_dist_dir, fcc_lang=fcc_lang
+        curriculum_dist=curriculum_dist, fcc_lang=fcc_lang
     ):
         redirect_path = f"{redir_slug}"
         redirect_url = redir_slug.count("/") * "../" + f"index.html#{redir_slug}"

--- a/scraper/src/fcc2zim/entrypoint.py
+++ b/scraper/src/fcc2zim/entrypoint.py
@@ -96,24 +96,24 @@ def main():
         default=False,
     )
     parser.add_argument(
-        "--output-dir",
+        "--output",
         type=str,
         help="Output directory where zim file will be built",
-        default=os.getenv("OUTPUT_DIR", "../output"),
+        default=os.getenv("FCC_OUTPUT", "../output"),
     )
     parser.add_argument(
-        "--build-dir",
+        "--build",
         type=str,
         help="The build directory to hold temporary files during scraper operation",
-        default=os.getenv("BUILD_DIR", "../build"),
+        default=os.getenv("FCC_BUILD", "../build"),
     )
     parser.add_argument(
-        "--zimui-dist-dir",
+        "--zimui-dist",
         type=str,
         help=(
             "Directory containing Vite build output from the Zim UI Vue.JS application"
         ),
-        default=os.getenv("ZIMUI_DIST_DIR", "../zimui/dist"),
+        default=os.getenv("FCC_ZIMUI_DIST", "../zimui/dist"),
     )
     parser.add_argument(
         "--zim-file",
@@ -143,9 +143,9 @@ def main():
         do_fetch=os.getenv("DO_FETCH", "False").lower() == "true",
         do_prebuild=os.getenv("DO_PREBUILD", "False").lower() == "true",
         do_build=os.getenv("DO_BUILD", "False").lower() == "true",
-        zimui_dist_dir=args.zimui_dist_dir,
-        output_dir=args.output_dir,
-        build_dir=args.build_dir,
+        zimui_dist=args.zimui_dist,
+        output=args.output,
+        build=args.build,
         language=args.language,
         name=args.name,
         title=args.title,

--- a/scraper/src/fcc2zim/fetch.py
+++ b/scraper/src/fcc2zim/fetch.py
@@ -7,7 +7,7 @@ import requests
 from fcc2zim.constants import Global
 
 
-def fetch_command(zip_path: Path, curriculum_raw_dir: Path, *, force: bool):
+def fetch_command(zip_path: Path, curriculum_raw: Path, *, force: bool):
     Global.logger.info("Scraper: fetch phase starting")
     url = "https://github.com/freeCodeCamp/freeCodeCamp/archive/refs/heads/main.zip"
 
@@ -19,8 +19,8 @@ def fetch_command(zip_path: Path, curriculum_raw_dir: Path, *, force: bool):
     else:
         Global.logger.debug(f"Using existing zip file {zip_path}")
 
-    curriculum_raw_dir.mkdir(parents=True, exist_ok=True)
-    shutil.rmtree(curriculum_raw_dir)
+    curriculum_raw.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(curriculum_raw)
 
     Global.logger.debug("Extracting files")
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
@@ -30,7 +30,7 @@ def fetch_command(zip_path: Path, curriculum_raw_dir: Path, *, force: bool):
             if member.startswith("freeCodeCamp-main/curriculum/")
             or member.startswith("freeCodeCamp-main/client/i18n/locales")
         ]
-        zip_ref.extractall(members=members, path=curriculum_raw_dir)
+        zip_ref.extractall(members=members, path=curriculum_raw)
         Global.logger.info(f"Extracted {len(members)} files")
-    Global.logger.info(f"Fetched curriculum into {curriculum_raw_dir}")
+    Global.logger.info(f"Fetched curriculum into {curriculum_raw}")
     Global.logger.info("Scraper: fetch phase finished")

--- a/scraper/src/fcc2zim/scraper.py
+++ b/scraper/src/fcc2zim/scraper.py
@@ -17,9 +17,9 @@ class Scraper:
         do_fetch: bool,
         do_prebuild: bool,
         do_build: bool,
-        zimui_dist_dir: str,
-        output_dir: str,
-        build_dir: str,
+        zimui_dist: str,
+        output: str,
+        build: str,
         language: str,
         name: str,
         title: str,
@@ -42,18 +42,18 @@ class Scraper:
         if not (self.do_fetch + self.do_prebuild + self.do_build):
             self.do_fetch = self.do_prebuild = self.do_build = True
 
-        self.zimui_dist_dir = Path(zimui_dist_dir)
-        if not self.zimui_dist_dir.exists():
-            raise ValueError(f"zimui_dist_dir {self.zimui_dist_dir} does not exists")
+        self.zimui_dist = Path(zimui_dist)
+        if not self.zimui_dist.exists():
+            raise ValueError(f"zimui_dist directory {self.zimui_dist} does not exists")
 
-        self.output_dir = Path(output_dir)
-        self.build_dir = Path(build_dir)
-        self.curriculum_raw_dir = self.build_dir.joinpath("curriculum-raw")
-        self.curriculum_dist_dir = self.build_dir.joinpath("curriculum-dist")
+        self.output = Path(output)
+        self.build = Path(build)
+        self.curriculum_raw = self.build.joinpath("curriculum-raw")
+        self.curriculum_dist = self.build.joinpath("curriculum-dist")
 
         # Make sure the output directory exists
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        self.build_dir.mkdir(parents=True, exist_ok=True)
+        self.output.mkdir(parents=True, exist_ok=True)
+        self.build.mkdir(parents=True, exist_ok=True)
 
         self.language = language
         if self.language not in FCC_LANG_MAP:
@@ -74,7 +74,7 @@ class Scraper:
         self.force = force
         self.course_csv = course_csv
         if not zip_path:
-            self.zip_path = self.build_dir.joinpath("main.zip")
+            self.zip_path = self.build.joinpath("main.zip")
         else:
             self.zip_path = Path(zip_path)
             if not self.zip_path.exists():
@@ -94,7 +94,7 @@ class Scraper:
             self.zim_path = Path(f"{name}_{period}.zim")
 
         # build full path
-        self.zim_path = self.output_dir.joinpath(self.zim_path)
+        self.zim_path = self.output.joinpath(self.zim_path)
 
         if self.zim_path.exists():
             if not self.force:
@@ -147,20 +147,20 @@ class Scraper:
         if self.do_fetch:
             fetch_command(
                 force=self.force,
-                curriculum_raw_dir=self.curriculum_raw_dir,
+                curriculum_raw=self.curriculum_raw,
                 zip_path=self.zip_path,
             )
         if self.do_prebuild:
             prebuild_command(
                 fcc_lang=self.fcc_lang,
                 course_csv=self.course_csv,
-                curriculum_raw_dir=self.curriculum_raw_dir,
-                curriculum_dist_dir=self.curriculum_dist_dir,
+                curriculum_raw=self.curriculum_raw,
+                curriculum_dist=self.curriculum_dist,
             )
         if self.do_build:
             build_command(
                 fcc_lang=self.fcc_lang,
                 creator=self.creator,
-                zimui_dist_dir=self.zimui_dist_dir,
-                curriculum_dist_dir=self.curriculum_dist_dir,
+                zimui_dist=self.zimui_dist,
+                curriculum_dist=self.curriculum_dist,
             )

--- a/scraper/tests/test_scraper.py
+++ b/scraper/tests/test_scraper.py
@@ -76,9 +76,9 @@ class TestScraper:
         do_fetch: bool = True,
         do_prebuild: bool = True,
         do_build: bool = True,
-        zimui_dist_dir: str = str(ZIMUI_DIST_PATH),
-        output_dir: str = str(OUTPUT_PATH),
-        build_dir: str = str(BUILD_PATH),
+        zimui_dist: str = str(ZIMUI_DIST_PATH),
+        output: str = str(OUTPUT_PATH),
+        build: str = str(BUILD_PATH),
         language: str = "eng",
         name="fcc_en_javascript",
         title="freeCodeCamp Javascript",
@@ -96,9 +96,9 @@ class TestScraper:
             do_fetch=do_fetch,
             do_prebuild=do_prebuild,
             do_build=do_build,
-            zimui_dist_dir=zimui_dist_dir,
-            output_dir=output_dir,
-            build_dir=build_dir,
+            zimui_dist=zimui_dist,
+            output=output,
+            build=build,
             language=language,
             name=name,
             title=title,
@@ -151,9 +151,9 @@ class TestScraper:
         assert scraper.do_prebuild == expected_do_prebuild
         assert scraper.do_build == expected_do_build
 
-    def test_zimui_dist_dir_ko(self):
+    def test_zimui_dist_ko(self):
         with pytest.raises(ValueError):
-            self.create_scraper(zimui_dist_dir="whatever")
+            self.create_scraper(zimui_dist="whatever")
 
     @pytest.mark.parametrize(
         "language, expected_fcc_lang",


### PR DESCRIPTION
## Changed

- Remove _dir prefix from input flag and variables/arguments names

## Rationale

Convention in scraper is that the output directory is passed in an --output flag (and not --output-dir).

Prefixing variable names with kind/type is not always recommended.

For both reasons, and for homogenity, all flags, variables, arguments have no more "_dir" or "-dir" suffix.