### PR TITLE
Replace ENTRYPOINT by CMD in Docker image

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -63,4 +63,4 @@ jobs:
 
       - name: Ensure we can start the Docker image
         run: |
-          docker run --rm testimage --version
+          docker run --rm testimage fcc2zim --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Replace ENTRYPOINT by CMD in Docker image
+
 ## [1.1.0] - 2023-08-31
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ ENV FCC_BUILD=/tmp
 ENV FCC_OUTPUT=/output
 ENV FCC_ZIMUI_DIST=/src/zimui
 
-ENTRYPOINT ["fcc2zim"]
+CMD ["fcc2zim", "--help"]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ hatch run fcc2zim --language eng --course "regular-expressions,basic-javascript,
 Run from official version (published on GHCR.io) ; ZIM will be available in the `output` sub-folder of current working directory.
 
 ```
-docker run --rm -it -v $(pwd)/output:/output ghcr.io/openzim/freecodecamp:latest --language eng --course "regular-expressions,basic-javascript,basic-data-structures,debugging,functional-programming,object-oriented-programming,basic-algorithm-scripting,intermediate-algorithm-scripting,javascript-algorithms-and-data-structures-projects" --name "fcc_en_javascript" --title "freeCodeCamp Javascript" --description "FCC Javascript Courses"
+docker run --rm -it -v $(pwd)/output:/output ghcr.io/openzim/freecodecamp:latest fcc2zim --language eng --course "regular-expressions,basic-javascript,basic-data-structures,debugging,functional-programming,object-oriented-programming,basic-algorithm-scripting,intermediate-algorithm-scripting,javascript-algorithms-and-data-structures-projects" --name "fcc_en_javascript" --title "freeCodeCamp Javascript" --description "FCC Javascript Courses"
 ```
 
 ## Course Options and Limitations

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
   { name = "Kiwix", email = "dev@kiwix.org" },
 ]
 keywords = ["fcc","freecodecamp","zim","kiwix","openzim","offline"]
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.12"
 description = "Make ZIM files from freeCodeCamp courses"
 readme = "../README.md"
 license = {text = "GPL-3.0-or-later"}


### PR DESCRIPTION
## Rationale

Fix #28 

## Changed
- use CMD instead of ENTRYPOINT in Docker image
- force Python 3.11 (do not yet use Python 3.12)