### PR TITLE
Default publisher set to `openZIM`

### DIFF
--- a/scraper/src/fcc2zim/entrypoint.py
+++ b/scraper/src/fcc2zim/entrypoint.py
@@ -81,7 +81,7 @@ def main():
         default="freeCodeCamp",
     )
     parser.add_argument(
-        "--publisher", type=str, help="Publisher of the zim file", default="OpenZIM"
+        "--publisher", type=str, help="Publisher of the zim file", default="openZIM"
     )
     parser.add_argument(
         "--force",


### PR DESCRIPTION
## Description

This pull request sets the default publisher to `openZIM` in the `/scraper/src/fcc2zim/entrypoint.py` file.

## Related Issue
Fix https://github.com/openzim/freecodecamp/issues/31

## Observations

There are two files where we explicitly set the publisher to `openZIM`:

- In `test_scraper.py`, the value is correctly set to `openZIM`.
![image](https://github.com/openzim/freecodecamp/assets/99159580/6176130c-1db6-4911-bfa8-288505188611)

- In `entrypoint.py`, it was originally set to `OpenZIM`, but has now been corrected to `openZIM`.
![image](https://github.com/openzim/freecodecamp/assets/99159580/61921f62-80f5-426c-9397-9655ecb80135)