### PR TITLE
Remove support for dark/light color schemes since incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix support for all FCC supported spoken languages (#20)
+- Remove incomplete support of dark mode, no more white on white text: not readable (#33)
 
 ## [1.1.1] - 2023-12-18
 

--- a/zimui/src/style.css
+++ b/zimui/src/style.css
@@ -13,9 +13,8 @@ body {
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -42,7 +41,7 @@ a {
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #747bff;
 }
 
 body {
@@ -68,7 +67,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f9f9f9;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -88,17 +87,4 @@ button:focus-visible {
   margin: 0 auto;
   text-align: left;
   height: 100%;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
Fix #33 

Changes:

- remove support for dark/light color schemes, use only light one (which is also more readable when it comes to colors in code editor)

![image](https://github.com/user-attachments/assets/d15e78d8-bf9d-43ea-b0b5-25307bec7ba2)


Nota: support for dark mode might be added back at a later stage, but for now this is not a priority, we want something which is readable at minimum support cost, so that we can make a 1.2 release with ZIMs always readable