### PR TITLE
Add CLI argument --overwrite to delete existing ZIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix support for all FCC supported spoken languages (#20)
 - Remove incomplete support of dark mode, no more white on white text: not readable (#33)
 
+### Added
+
+- Add --overwrite CLI argument to not fail when ZIM already exists (#44)
+
 ## [1.1.1] - 2023-12-18
 
 ### Fixed

--- a/scraper/src/fcc2zim/entrypoint.py
+++ b/scraper/src/fcc2zim/entrypoint.py
@@ -137,6 +137,12 @@ def main():
         action="version",
         version=f"fcc2zim {VERSION}",
     )
+    parser.add_argument(
+        "--overwrite",
+        help="Do not fail if ZIM already exists, overwrite it",
+        action="store_true",
+        dest="overwrite_existing_zim",
+    )
 
     args = parser.parse_args()
 
@@ -163,6 +169,7 @@ def main():
         course_csv=args.course,
         zip_main_path=args.zip_path,
         zip_i18n_path=args.i18n_zip_path,
+        overwrite_existing_zim=args.overwrite_existing_zim,
         start_date=datetime.date.today(),
     )
 

--- a/scraper/src/fcc2zim/scraper.py
+++ b/scraper/src/fcc2zim/scraper.py
@@ -32,6 +32,7 @@ class Scraper:
         course_csv: str,
         zip_main_path: str | None,
         zip_i18n_path: str | None,
+        overwrite_existing_zim: bool,
         start_date: datetime.date,
     ):
         self.do_fetch = do_fetch
@@ -104,7 +105,7 @@ class Scraper:
         self.zim_path = self.output.joinpath(self.zim_path)
 
         if self.zim_path.exists():
-            if not self.force:
+            if not (self.force or overwrite_existing_zim):
                 raise ValueError(f"ZIM file {self.zim_path} already exist.")
             Global.logger.info(f"Removing existing ZIM file {self.zim_path}")
             self.zim_path.unlink()

--- a/scraper/tests/test_scraper.py
+++ b/scraper/tests/test_scraper.py
@@ -91,6 +91,7 @@ class TestScraper:
         course_csv="regular-expressions,basic-javascript",
         zip_main_path: str | None = None,
         zip_i18n_path: str | None = None,
+        overwrite_existing_zim: bool = False,
         start_date: datetime.date = DEFAULT_START_DATE,
     ):
         return Scraper(
@@ -112,6 +113,7 @@ class TestScraper:
             course_csv=course_csv,
             zip_main_path=zip_main_path,
             zip_i18n_path=zip_i18n_path,
+            overwrite_existing_zim=overwrite_existing_zim,
             start_date=start_date,
         )
 


### PR DESCRIPTION
Fix #44 

While the `--force` option already exists, it does far more than just overwriting the existing ZIM. I feel like a dedicated CLI argument just for the ZIM is worth it.