### PR TITLE
Move link to go to next challenge as a real button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix support for all FCC supported spoken languages (#20)
 - Remove incomplete support of dark mode, no more white on white text: not readable (#33)
 - Parse properly markdown property with colon and quotes (#6)
+- Move button to go to next challenge so that it is more obvious (#56)
 
 ### Added
 

--- a/zimui/src/components/challenge/ChallengeRunner.vue
+++ b/zimui/src/components/challenge/ChallengeRunner.vue
@@ -42,6 +42,14 @@ watch(
 
 <template>
   <button @click="runTest">Run the tests</button>
+  <div v-if="passed" class="passed">
+    <p>Passed!</p>
+    <p v-if="nextChallenge">
+      <router-link :to="nextChallenge.url">
+        <button>Move to next challenge</button>
+      </router-link>
+    </p>
+  </div>
   <button @click="emit('reset')">Reset this lesson</button>
   <p
     v-for="(test, i) in result?.hints"
@@ -51,14 +59,6 @@ watch(
   >
     {{ test.description }}
   </p>
-  <div v-if="passed" class="passed">
-    <p>Passed!</p>
-    <p v-if="nextChallenge">
-      <router-link :to="nextChallenge.url">{{
-        nextChallenge.title
-      }}</router-link>
-    </p>
-  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
Currently, the "Passed !" text when a challenge is passed is hidden at the bottom of the left pane, it is not a button, and the message is next challenge title which is far from being obvious.

This PR is a very quick enhancement moving this text next to the "Run the tests" button, with a real button, a nice color (accidental ...) and a clear CTA.

![Screenshot 2025-01-13 at 16 17 40](https://github.com/user-attachments/assets/3cd7ad4d-1bf9-45cb-8f94-f7682f7d8ebb)

This is just meant to ease the situation until 2.0.0 is implemented.