### PR TITLE
Add breadcrumbs

### DIFF
--- a/zimui/src/components/challenge/ChallengeInstructions.vue
+++ b/zimui/src/components/challenge/ChallengeInstructions.vue
@@ -5,6 +5,9 @@ const props = defineProps<{
   title: string
   description: string
   instructions: string
+  coursetitle: string
+  coursepath: string
+  curriculumtitle: string
 }>()
 
 const render = (str: string): string => {
@@ -15,6 +18,14 @@ const render = (str: string): string => {
 <template>
   <!-- eslint-disable vue/no-v-html -->
   <h1>{{ props.title }}</h1>
+  <p>
+    <RouterLink to="/">
+      &gt; {{ curriculumtitle }}
+    </RouterLink>
+    <RouterLink :to="coursepath">
+      &gt; {{ coursetitle }}
+    </RouterLink>
+  </p>
   <div class="markdown">
     <div v-html="render(props.description)" />
     <hr />

--- a/zimui/src/pages/ChallengePage.vue
+++ b/zimui/src/pages/ChallengePage.vue
@@ -26,6 +26,8 @@ const logs: Ref<string[]> = ref([])
 
 const challengesMeta = await (await fetch(`content/curriculum/${params.value.superblock}/${params.value.course}/_meta.json`)).json()
 
+const locales = (await (await fetch(`content/locales/intro.json`)).json())[params.value.superblock as string]
+
 challenges.value = (challengesMeta as ChallengesJSON)['challenges']
 
 const updateChallenge = async (newparams: RouteParams) => {
@@ -83,6 +85,9 @@ await updateChallenge(params.value)
         :title="challenge.header['title']"
         :instructions="challenge.instructions || ''"
         :description="challenge.description"
+        :coursetitle="locales.blocks[params.course as string].title"
+        :coursepath="`/${params.superblock}/${params.course}`"
+        :curriculumtitle="locales.title"
       ></ChallengeInstructions>
       <ChallengeRunner
         :challenge="challenge"

--- a/zimui/src/pages/ChallengesPage.vue
+++ b/zimui/src/pages/ChallengesPage.vue
@@ -13,7 +13,7 @@ const locales = (await (await fetch(`content/locales/intro.json`)).json())[param
 
 <template>
   <div class="card centered">
-    <h1>{{ locales.title }}</h1>
+    <h1>{{ locales.blocks[params.course as string].title }}</h1>
     <p>
       <RouterLink :to="`/`">
         &gt; {{ locales.title }}

--- a/zimui/src/pages/ChallengesPage.vue
+++ b/zimui/src/pages/ChallengesPage.vue
@@ -14,6 +14,11 @@ const locales = (await (await fetch(`content/locales/intro.json`)).json())[param
 <template>
   <div class="card centered">
     <h1>{{ locales.title }}</h1>
+    <p>
+      <RouterLink :to="`/`">
+        &gt; {{ locales.title }}
+      </RouterLink>
+    </p>
     <p v-for="(p, idx) in locales.intro" :key="idx" class="my-2">{{ p }}</p>
     <ul>
       <li v-for="item in challenges" :key="item.slug">


### PR DESCRIPTION
Changes:
- add breadcrumbs for easier navigation
- fix the title displayed when listing course content (challenges). It was the superblock / curriculum title which was kinda confusing.