### PR TITLE
Do not parse the whole markdown as YAML, but only the frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove undecided Chinese codes
 - Remove obsolete/missing arabic code
 - Add missing support for swahili (#66)
+- Do not parse the whole markdown as YAML, but only the frontmatter (#64)
 
 ## [1.2.0] - 2025-01-16
 

--- a/scraper/src/fcc2zim/challenge.py
+++ b/scraper/src/fcc2zim/challenge.py
@@ -1,16 +1,17 @@
 import pathlib
+import re
 
 import yaml
+
+FRONTMATTER_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
 
 
 # Each markdown challenge contains 'frontmatter' which is a header
 # consisting of yaml formatted data enclosed inside of '---\n' lines
-# '---' lines in YAML denote multiple documents, so this can be read
-# directly with python's yaml library pulling in the first document
-# with 'next' and immediately returning
+# We load into YAML only the frontmatter
 def read_yaml_frontmatter(filename: pathlib.Path):
-    with open(filename) as f:
-        return next(yaml.load_all(f, Loader=yaml.FullLoader))
+    _, fm, _ = FRONTMATTER_BOUNDARY.split(filename.read_text("UTF8"), 2)
+    return yaml.load(fm, Loader=yaml.SafeLoader)
 
 
 class Challenge:

--- a/scraper/tests/test_challenge.py
+++ b/scraper/tests/test_challenge.py
@@ -1,0 +1,15 @@
+import tempfile
+from pathlib import Path
+
+from fcc2zim.challenge import read_yaml_frontmatter
+
+
+def test_good_front_matter():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        md_file = Path(tmp_dir) / "file.md"
+        # dd:ee\ndd: is bad YAML which is intentionaly here, because outside
+        # the front matter and should hence be properly ignored
+        md_file.write_text("----\ntitle: foo\nsubject: bar\n---\ndd:ee\ndd:")
+        front = read_yaml_frontmatter(md_file)
+        assert front["title"] == "foo"
+        assert front["subject"] == "bar"


### PR DESCRIPTION
Fix #64

Nota: tested succesfully on `freecodecamp_es_rosetta-code` on my local machine