### PR TITLE
Add support for custom ZIM illustration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make the UI responsive (#22)
 - Enhance the UI design to be closer to original FCC UI (#23)
+- Add support for custom ZIM illustration (#79)
 
 ## [1.3.0] - 2025-01-24
 

--- a/scraper/src/fcc2zim/context.py
+++ b/scraper/src/fcc2zim/context.py
@@ -70,6 +70,9 @@ class Context:
     # Date when the crawl started
     start_date: datetime.date
 
+    # Path or URL to use as ZIM illustration
+    illustration: str | None = None
+
     # logger to use everywhere (do not mind about mutability, we want to reuse same
     # logger everywhere)
     logger: logging.Logger = getLogger(  # noqa: RUF009

--- a/scraper/src/fcc2zim/entrypoint.py
+++ b/scraper/src/fcc2zim/entrypoint.py
@@ -146,6 +146,11 @@ def prepare_context(raw_args: list[str]) -> None:
         dest="overwrite_existing_zim",
     )
 
+    parser.add_argument(
+        "--illustration",
+        help="Path or URL to ZIM illustration. Bitmap and SVG formats are supported.",
+    )
+
     args = parser.parse_args(raw_args)
 
     # Ignore unset values so they do not override the default specified in Context


### PR DESCRIPTION
Fix #79 

**Nota:** I consider that this code should ultimately make its way to the python-scraperlib since it is a very generic way to handle ZIM illustration which probably matches most scraper needs. Could even be hidden behind the `DefaultIllustrationMetadata` which could accept a string as well as input and if such consider that it is the path or URL to illustration to use.