### PR TITLE
feat: add dark theme using prefers-color-scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add a visual red flash when "Check Your Code" tests fail (#126)
+- Add dark theme support using prefers-color-scheme (#131)
 
 ### Fixed
 

--- a/zimui/package.json
+++ b/zimui/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.2",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@freecodecamp/curriculum-helpers": "^3.8.0",
     "axios": "^1.8.2",
     "chai": "^5.1.2",

--- a/zimui/public/custom.css
+++ b/zimui/public/custom.css
@@ -3,7 +3,7 @@ html {
 }
 
 body {
-  background-color: #f5f6f7;
+  background-color: var(--secondary-background, #f5f6f7);
 }
 
 p {
@@ -16,13 +16,13 @@ a[href^="https://"]
   /* modify all <a> tag so that the :after is centered */
   display: inline-flex;
   align-items: center;
-  color: #df2121;
+  color: var(--link-color, #df2121);
 }
 
 a[href^="http://"]:hover,
 a[href^="https://"]:hover
 {
-  color: #df2121;
+  color: var(--link-color, #df2121);
 }
 
 a[href^="http://"]:after,
@@ -49,7 +49,8 @@ a[href^="https://"]:after
 }
 .markdown table thead {
   border-color: inherit;
-  background-color: lightblue;
+  background-color: var(--table-header-bg, lightblue);
+  color: var(--table-header-color, inherit);
   display: table-header-group;
   vertical-align: middle;
 }
@@ -58,10 +59,10 @@ a[href^="https://"]:after
 }
 .markdown table td,
 .markdown table th {
-  border: 1px solid black;
+  border: 1px solid var(--table-border, black);
   padding: 6px 13px;
   text-align: center;
 }
 .markdown table tbody tr:nth-of-type(odd) {
-  background-color: rgb(211, 211, 211, 0.3);
+  background-color: var(--table-row-odd, rgba(211, 211, 211, 0.3));
 }

--- a/zimui/src/components/CourseBlocks.vue
+++ b/zimui/src/components/CourseBlocks.vue
@@ -63,7 +63,7 @@ const completedChallengesCount = computed(() => {
 
 <style scoped>
 button {
-  background-color: white;
+  background-color: var(--primary-background);
   width: 100%;
   display: flex;
   gap: 10px;
@@ -71,11 +71,12 @@ button {
   padding: 18px 15px;
   font-size: 1.13rem;
   border: none;
+  color: var(--primary-color);
 }
 
 button:hover {
-  color: #2a2a40;
-  background-color: #dfdfe2;
+  color: var(--secondary-color);
+  background-color: var(--hover-background);
 }
 
 img.icon {
@@ -105,14 +106,21 @@ div.completed {
 }
 
 .challenges a:hover {
-  color: #2a2a40;
-  background-color: #dfdfe2;
+  color: var(--secondary-color);
+  background-color: var(--hover-background);
 }
 
 @media (max-width: 500px) {
   button,
   .challenges a {
     font-size: 1rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  img.icon,
+  .challenges img {
+    filter: invert(1);
   }
 }
 </style>

--- a/zimui/src/components/CurriculumsOverview.vue
+++ b/zimui/src/components/CurriculumsOverview.vue
@@ -47,9 +47,9 @@ div.course {
   display: flex;
   align-items: center;
   gap: 15px;
-  background-color: #d0d0d5;
-  border: 3px solid #1b1b32;
-  color: #1b1b32;
+  background-color: var(--button-background);
+  border: 3px solid var(--foreground-accent);
+  color: var(--primary-color);
   font-size: 1.1rem;
   margin-bottom: 10px;
   min-height: 80px;
@@ -107,6 +107,12 @@ ul {
   }
   blockquote {
     font-size: 1.2rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  img {
+    filter: invert(1);
   }
 }
 </style>

--- a/zimui/src/components/ErrorInfo.vue
+++ b/zimui/src/components/ErrorInfo.vue
@@ -28,9 +28,9 @@ import dead_kiwix from '../assets/dead_kiwix.png'
   align-items: center;
   gap: 40px;
   margin: 60px 0;
-  background: white;
+  background: var(--primary-background);
   border-radius: 10px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 20px var(--shadow-color);
   padding: 40px;
 }
 .content {
@@ -38,7 +38,7 @@ import dead_kiwix from '../assets/dead_kiwix.png'
   text-align: left;
 }
 .text {
-  color: #222;
+  color: var(--primary-color);
   margin: 10px 0;
   max-width: 500px;
   line-height: 1.6;

--- a/zimui/src/components/HeaderBar.vue
+++ b/zimui/src/components/HeaderBar.vue
@@ -31,7 +31,7 @@ onMounted(async () => {
 
 <style scoped>
 .header-bar {
-  background-color: #0a0a23;
+  background-color: var(--header-background);
 }
 
 #logo {

--- a/zimui/src/components/SuperblockIcon.vue
+++ b/zimui/src/components/SuperblockIcon.vue
@@ -88,4 +88,10 @@ const icon = computed(() => {
   <img :src="icon" aria-hidden="true" />
 </template>
 
-<style scoped></style>
+<style scoped>
+@media (prefers-color-scheme: dark) {
+  img {
+    filter: invert(1);
+  }
+}
+</style>

--- a/zimui/src/components/SuperblockOverview.vue
+++ b/zimui/src/components/SuperblockOverview.vue
@@ -84,14 +84,14 @@ h3 {
 }
 
 div.block {
-  background-color: white;
+  background-color: var(--primary-background);
   margin-bottom: 30px;
 }
 
 div.block-description {
   padding: 0 15px 15px;
   font-size: 1.17rem;
-  border-bottom: 3px solid #f5f6f7;
+  border-bottom: 3px solid var(--secondary-background);
 }
 
 .icon {

--- a/zimui/src/components/challenge/ChallengeBreadcrumbs.vue
+++ b/zimui/src/components/challenge/ChallengeBreadcrumbs.vue
@@ -36,7 +36,7 @@ const course = computed(() => singlePathParam(route.params.course))
 }
 
 nav {
-  border: 1px solid #d0d0d5;
+  border: 1px solid var(--border-color);
 }
 
 ol {
@@ -45,7 +45,7 @@ ol {
 }
 
 .breadcrumb-left {
-  background-color: #d0d0d5;
+  background-color: var(--button-background);
   margin-inline-end: 0.57rem;
   min-width: 3rem;
 }
@@ -55,9 +55,9 @@ ol {
 }
 
 .breadcrumb-left::after {
-  background-color: #f5f6f7;
+  background-color: var(--secondary-background);
   border-bottom: 0.6rem solid transparent;
-  border-inline-start: 0.55rem solid #d0d0d5;
+  border-inline-start: 0.55rem solid var(--button-background);
   border-top: 0.6875rem solid transparent;
   content: '';
   height: 100%;

--- a/zimui/src/components/challenge/ChallengeDesktop.vue
+++ b/zimui/src/components/challenge/ChallengeDesktop.vue
@@ -67,7 +67,7 @@ function checkCode() {
 
 .topright {
   display: flex;
-  background-color: white;
+  background-color: var(--editor-background);
 }
 
 .code-editor {
@@ -81,8 +81,9 @@ function checkCode() {
 button {
   font-size: 1.2rem;
   width: 100%;
-  border: 3px solid #1b1b32;
-  background-color: #d0d0d5;
+  border: 3px solid var(--foreground-accent);
+  background-color: var(--button-background);
+  color: var(--button-color);
   padding: 0.375rem 0.75rem;
   margin: 0 0 0.5rem;
 }

--- a/zimui/src/components/challenge/ChallengeDialogs.vue
+++ b/zimui/src/components/challenge/ChallengeDialogs.vue
@@ -117,6 +117,8 @@ const resetWarnMessage = computed(() => {
 <style scoped>
 .v-sheet {
   text-align: center;
+  background-color: var(--primary-background);
+  color: var(--primary-color);
 }
 
 .v-sheet > * {
@@ -139,7 +141,7 @@ const resetWarnMessage = computed(() => {
 
 .header,
 .message {
-  border-bottom: 1px solid #1b1b32;
+  border-bottom: 1px solid var(--foreground-accent);
 }
 
 .header h2 {
@@ -165,29 +167,35 @@ const resetWarnMessage = computed(() => {
 }
 
 .danger {
-  color: #850000;
+  color: var(--danger-color);
 }
 
 .danger .header {
-  background-color: #ffadad;
+  background-color: var(--danger-background);
 }
 
 .danger button.reset {
-  color: #ffadad;
-  background-color: #850000;
+  color: var(--danger-background);
+  background-color: var(--danger-color);
   font-size: 1.4rem;
   width: 100%;
   padding: 0.625rem 1rem;
-  border: 3px solid #ffadad;
+  border: 3px solid var(--danger-background);
 }
 
 .passed button.next {
-  color: #1b1b32;
-  background-color: #d0d0d5;
+  color: var(--button-color);
+  background-color: var(--button-background);
   font-size: 1.4rem;
   width: 100%;
   padding: 0.625rem 1rem;
-  border: 3px solid #1b1b32;
+  border: 3px solid var(--foreground-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  .big_passed {
+    filter: invert(1);
+  }
 }
 
 .big_passed {

--- a/zimui/src/components/challenge/ChallengeInstructions.vue
+++ b/zimui/src/components/challenge/ChallengeInstructions.vue
@@ -36,10 +36,10 @@ div.markdown p:last-child {
 
 div.markdown code {
   padding: 1px 4px;
-  border: 1px solid #858591;
-  background-color: #dfdfe2;
+  border: 1px solid var(--code-border);
+  background-color: var(--code-background);
   border-radius: 0;
-  color: #2a2a40;
+  color: var(--code-color);
   font-family: 'Hack-ZeroSlash';
   overflow-wrap: anywhere;
   font-size: 1.1rem;
@@ -47,12 +47,12 @@ div.markdown code {
 
 div.markdown strong {
   font-weight: 700;
-  color: #1b1b32;
+  color: var(--primary-color);
 }
 
 div.markdown hr {
   border: 0;
-  border-top: 1px solid #d0d0d5;
+  border-top: 1px solid var(--hr-color);
   margin-bottom: 20px;
   margin-top: 20px;
 }

--- a/zimui/src/components/challenge/ChallengeMobile.vue
+++ b/zimui/src/components/challenge/ChallengeMobile.vue
@@ -108,26 +108,26 @@ function checkCode() {
 }
 
 .header > button.active {
-  background-color: #3b3b4f;
-  color: #fff;
+  background-color: var(--tab-active-background);
+  color: var(--tab-active-color);
 }
 
 .header {
-  border-bottom: 1px solid #3b3b4f;
+  border-bottom: 1px solid var(--tab-active-background);
 }
 
 .footer > button {
-  background-color: #d0d0d5;
-  color: #1b1b32;
-  border: 3px solid #1b1b32;
+  background-color: var(--button-background);
+  color: var(--button-color);
+  border: 3px solid var(--foreground-accent);
 }
 
 .footer {
-  border-top: 1px solid #fff;
+  border-top: 1px solid var(--primary-background);
 }
 
 .code-editor {
-  background-color: #fff;
+  background-color: var(--editor-background);
 }
 
 </style>

--- a/zimui/src/components/challenge/ChallengeTests.vue
+++ b/zimui/src/components/challenge/ChallengeTests.vue
@@ -24,17 +24,17 @@ const main = useMainStore()
 <style>
 ul.tests code {
   padding: 1px 4px;
-  border: 1px solid #858591;
-  background-color: #dfdfe2;
+  border: 1px solid var(--code-border);
+  background-color: var(--code-background);
   border-radius: 0;
-  color: #2a2a40;
+  color: var(--code-color);
   font-family: 'Hack-ZeroSlash';
   overflow-wrap: anywhere;
   font-size: 1.1rem;
 }
 
 ul.tests li:nth-child(2n + 1) code {
-  background-color: #f5f6f7;
+  background-color: var(--secondary-background);
 }
 </style>
 
@@ -56,12 +56,18 @@ ul.tests li:nth-child(2n + 1) code {
 }
 
 .hint:nth-child(2n + 1) {
-  background-color: #dfdfe2;
+  background-color: var(--tertiary-background);
 }
 
 h2.tests {
   text-align: center;
   padding: 0.5rem 0 1rem;
   font-size: 1.1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .result img {
+    filter: invert(1);
+  }
 }
 </style>

--- a/zimui/src/components/challenge/CodeEditor.vue
+++ b/zimui/src/components/challenge/CodeEditor.vue
@@ -1,13 +1,35 @@
 <script setup lang="ts">
-import { shallowRef } from 'vue'
+import { shallowRef, ref, computed, onUnmounted } from 'vue'
 import { Codemirror } from 'vue-codemirror'
 import { javascript } from '@codemirror/lang-javascript'
+import { oneDark } from '@codemirror/theme-one-dark'
 import { EditorView } from '@codemirror/view'
 import { useMainStore } from '@/stores/main'
 
 const main = useMainStore()
 
-const extensions = [javascript()]
+const darkQuery: MediaQueryList | null =
+  typeof window !== 'undefined' && 'matchMedia' in window
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : null
+const prefersDark = ref(darkQuery ? darkQuery.matches : false)
+if (darkQuery) {
+  const onChange = (e: MediaQueryListEvent) => {
+    prefersDark.value = e.matches
+  }
+  if (typeof darkQuery.addEventListener === 'function') {
+    darkQuery.addEventListener('change', onChange)
+    onUnmounted(() => darkQuery.removeEventListener('change', onChange))
+  } else if (typeof darkQuery.addListener === 'function') {
+    darkQuery.addListener(onChange)
+    onUnmounted(() => darkQuery.removeListener(onChange))
+  }
+}
+
+const js = javascript()
+const extensions = computed(() =>
+  prefersDark.value ? [js, oneDark] : [js]
+)
 
 // Codemirror EditorView instance ref
 const view = shallowRef()

--- a/zimui/src/style.css
+++ b/zimui/src/style.css
@@ -1,12 +1,93 @@
 :root {
-  color: #213547;
-  background-color: #ffffff;
+  color-scheme: light dark;
+
+  /* gray scale */
+  --gray-00: #ffffff;
+  --gray-05: #f5f6f7;
+  --gray-10: #dfdfe2;
+  --gray-15: #d0d0d5;
+  --gray-45: #858591;
+  --gray-75: #3b3b4f;
+  --gray-80: #2a2a40;
+  --gray-85: #1b1b32;
+  --gray-90: #0a0a23;
+
+  /* theme */
+  --primary-color: var(--gray-85);
+  --secondary-color: var(--gray-80);
+  --primary-background: var(--gray-00);
+  --secondary-background: var(--gray-05);
+  --tertiary-background: var(--gray-10);
+  --border-color: var(--gray-15);
+  --foreground-accent: var(--gray-85);
+  --button-background: var(--gray-15);
+  --button-color: var(--gray-85);
+  --code-background: var(--gray-10);
+  --code-color: var(--gray-80);
+  --code-border: var(--gray-45);
+  --tab-active-background: var(--gray-75);
+  --tab-active-color: var(--gray-00);
+  --header-background: var(--gray-90);
+  --editor-background: var(--gray-00);
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --danger-color: #850000;
+  --danger-background: #ffadad;
+  --link-color: #df2121;
+  --hr-color: var(--gray-15);
+  --splitter-background: var(--gray-10);
+  --splitter-border: var(--gray-05);
+  --hover-background: var(--gray-10);
+  --table-header-bg: lightblue;
+  --table-header-color: inherit;
+  --table-border: black;
+  --table-row-odd: rgba(211, 211, 211, 0.3);
+
+  color: var(--primary-color);
+  background-color: var(--primary-background);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary-color: var(--gray-05);
+    --secondary-color: var(--gray-10);
+    --primary-background: var(--gray-90);
+    --secondary-background: var(--gray-85);
+    --tertiary-background: var(--gray-80);
+    --border-color: var(--gray-75);
+    --foreground-accent: var(--gray-05);
+    --button-background: var(--gray-75);
+    --button-color: var(--gray-05);
+    --code-background: var(--gray-80);
+    --code-color: var(--gray-10);
+    --code-border: var(--gray-75);
+    --tab-active-background: var(--gray-05);
+    --tab-active-color: var(--gray-90);
+    --header-background: var(--gray-90);
+    --editor-background: #2a2b40;
+    --shadow-color: rgba(0, 0, 0, 0.4);
+    --danger-color: #ffadad;
+    --danger-background: #850000;
+    --link-color: #df2121;
+    --hr-color: var(--gray-75);
+    --splitter-background: var(--gray-80);
+    --splitter-border: var(--gray-85);
+    --hover-background: var(--gray-80);
+    --table-header-bg: var(--gray-80);
+    --table-header-color: var(--gray-10);
+    --table-border: var(--gray-75);
+    --table-row-odd: rgba(255, 255, 255, 0.05);
+  }
+
+  .cm-editor,
+  .cm-editor .cm-gutters {
+    background-color: var(--editor-background);
+  }
 }
 
 img {
@@ -44,8 +125,8 @@ button {
 }
 
 .splitpanes--vertical .splitpanes__splitter {
-  background: #dfdfe2;
-  border: 5px #f5f6f7;
+  background: var(--splitter-background);
+  border: 5px var(--splitter-border);
   min-width: 16px !important;
   border-left-style: solid;
   border-right-style: solid;

--- a/zimui/yarn.lock
+++ b/zimui/yarn.lock
@@ -891,6 +891,16 @@
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 
+"@codemirror/theme-one-dark@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz#1dbb73f6e73c53c12ad2aed9f48c263c4e63ea37"
+  integrity sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/highlight" "^1.0.0"
+
 "@codemirror/view@6.x", "@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0":
   version "6.38.7"
   resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.38.7.tgz#069df16ad10b85e02da2865c22de6082ebfbf48d"


### PR DESCRIPTION
## Summary
- Added dark theme support using CSS `color-scheme` and `prefers-color-scheme` primitives the way it was described in the issue
- Defined CSS custom variables based on codecamp's gray scale, with light defaults and dark overrides
- Replaced all the hardcoded colors across components with CSS variables
- Added `@codemirror/theme-one-dark` for the code editor in dark mode

Should close #131