### PR TITLE
Translation handling (#142)

### DIFF
--- a/.github/workflows/QA.yaml
+++ b/.github/workflows/QA.yaml
@@ -37,6 +37,10 @@ jobs:
         working-directory: scraper
         run: inv check-pyright
 
+      - name: Check UI translation keys
+        working-directory: scraper
+        run: inv check-ui-keys
+
   check-zimui-qa:
     runs-on: ubuntu-24.04
 

--- a/scraper/src/fcc2zim/check_ui_keys.py
+++ b/scraper/src/fcc2zim/check_ui_keys.py
@@ -1,0 +1,56 @@
+"""Checks that the ZIM UI only uses translation keys that are listed in ui_keys.yaml."""
+
+import re
+import sys
+from typing import cast
+
+import yaml
+
+from fcc2zim.constants import ROOT_DIR
+
+UI_KEYS_PATH = ROOT_DIR / "ui_keys.yaml"
+ZIMUI_SRC = ROOT_DIR.parent.parent.parent / "zimui" / "src"
+
+T_CALL_RE = re.compile(r"main\.t\('([^']+)'")
+
+
+def flatten_keys(
+    data: dict[str, object], prefix: tuple[str, ...] = ()
+) -> set[tuple[str, ...]]:
+    result: set[tuple[str, ...]] = set()
+    for key, value in data.items():
+        path = (*prefix, key)
+        if value is None:
+            result.add(path)
+        elif isinstance(value, dict):
+            dict_value = cast(dict[str, object], value)
+            if set(dict_value.keys()) == {"placeholders"}:
+                result.add(path)
+            else:
+                result.update(flatten_keys(dict_value, path))
+    return result
+
+
+def main() -> None:
+    spec: dict[str, object] = yaml.safe_load(UI_KEYS_PATH.read_text())
+    allowed = flatten_keys(spec)
+
+    errors: list[str] = []
+    for file in list(ZIMUI_SRC.rglob("*.vue")) + list(ZIMUI_SRC.rglob("*.ts")):
+        content = file.read_text()
+
+        for match in T_CALL_RE.finditer(content):
+            key_path = tuple(match.group(1).split("."))
+            if key_path not in allowed:
+                errors.append(f"{file.name}: unknown key {match.group(1)}")
+
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)  # noqa: T201
+        sys.exit(1)
+
+    print("All UI translation keys are in ui_keys.yaml")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/src/fcc2zim/locale_validation.py
+++ b/scraper/src/fcc2zim/locale_validation.py
@@ -1,0 +1,114 @@
+import json
+import re
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+from fcc2zim.constants import ROOT_DIR
+from fcc2zim.context import Context
+
+logger = Context.logger
+PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
+
+
+def validate_locales(locales_path: Path, included_superblocks: dict[str, list[str]]):
+    """Checks locale files against ui_keys.yaml and fails it if anything seems off."""
+
+    spec = yaml.safe_load((ROOT_DIR / "ui_keys.yaml").read_text())
+    translations = json.loads(
+        (locales_path / "translations.json").read_text(encoding="utf-8")
+    )
+    intro = json.loads((locales_path / "intro.json").read_text(encoding="utf-8"))
+    errors: list[str] = []
+
+    # checks static keys from translations.json and intro.json
+    for file_key, data in [("translations", translations), ("intro", intro)]:
+        if file_key not in spec:
+            continue
+        for section, keys in spec[file_key].items():
+            if section not in data:
+                errors.append(f"{file_key}.json: missing section '{section}'")
+                continue
+            for key, opts in keys.items():
+                if key not in data[section]:
+                    errors.append(f"{file_key}.json: missing key '{section}.{key}'")
+                    continue
+
+                value = data[section][key]
+                if not isinstance(value, str):
+                    continue
+
+                actual: set[str] = set(PLACEHOLDER_RE.findall(value))
+                expected: set[str] = (
+                    set(opts.get("placeholders", [])) if opts else set()
+                )
+
+                for name in expected - actual:
+                    errors.append(
+                        f"{file_key}.json: '{section}.{key}'"
+                        f" missing placeholder {{{{{name}}}}}"
+                    )
+                for name in actual - expected:
+                    errors.append(
+                        f"{file_key}.json: '{section}.{key}'"
+                        f" has unexpected placeholder {{{{{name}}}}}"
+                    )
+
+    # checks intro.json has entries for every included superblock/course
+    for superblock, courses in included_superblocks.items():
+        if superblock not in intro:
+            errors.append(f"intro.json: missing superblock '{superblock}'")
+            continue
+
+        sb = intro[superblock]
+        for field in ("title", "intro", "blocks"):
+            if field not in sb:
+                errors.append(f"intro.json: superblock '{superblock}' has no '{field}'")
+
+        # checks superblock intro has no unexpected placeholders
+        if "title" in sb and isinstance(sb["title"], str):
+            for ph in PLACEHOLDER_RE.findall(sb["title"]):
+                errors.append(
+                    f"intro.json: '{superblock}.title'"
+                    f" has unexpected placeholder {{{{{ph}}}}}"
+                )
+        if "intro" in sb and isinstance(sb["intro"], list):
+            for para in sb["intro"]:
+                if isinstance(para, str):
+                    for ph in PLACEHOLDER_RE.findall(para):
+                        errors.append(
+                            f"intro.json: '{superblock}.intro'"
+                            f" has unexpected placeholder {{{{{ph}}}}}"
+                        )
+
+        blocks = sb.get("blocks", {})
+        for course in courses:
+            if course not in blocks:
+                errors.append(
+                    f"intro.json: can't find block '{course}' in '{superblock}'"
+                )
+                continue
+            for field in ("title", "intro"):
+                if field not in blocks[course]:
+                    errors.append(f"intro.json: block '{course}' has no '{field}'")
+                    continue
+                val = blocks[course][field]
+                if isinstance(val, str):
+                    texts: list[str] = [val]
+                elif isinstance(val, list):
+                    texts = cast(list[str], val)
+                else:
+                    texts = []
+                for text in texts:
+                    for ph in PLACEHOLDER_RE.findall(text):
+                        errors.append(
+                            f"intro.json: '{superblock}.blocks.{course}.{field}'"
+                            f" has unexpected placeholder {{{{{ph}}}}}"
+                        )
+
+    if errors:
+        for err in errors:
+            logger.error(err)
+        raise ValueError(f"Locale validation failed with {len(errors)} error(s)")
+    logger.info("Locale files validated")

--- a/scraper/src/fcc2zim/prebuild.py
+++ b/scraper/src/fcc2zim/prebuild.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from fcc2zim.challenge import Challenge
 from fcc2zim.context import Context
+from fcc2zim.locale_validation import validate_locales
 
 logger = Context.logger
 
@@ -101,6 +102,8 @@ def prebuild_command(
         if "blocks" in superblock_content:
             superblocks[superblock_name] = superblock_content["blocks"]
 
+    included_superblocks: dict[str, list[str]] = {}
+
     # eg. ['basic-javascript', 'debugging']
     for course in course_list:
         logger.debug(f"Prebuilding {course}")
@@ -127,6 +130,10 @@ def prebuild_command(
             )
         superblock = matching_superblocks[0]
 
+        if superblock not in included_superblocks:
+            included_superblocks[superblock] = []
+        included_superblocks[superblock].append(course)
+
         challenge_list: list[Challenge] = []
         for file in get_challenges_for_lang(challenges, course, fcc_lang):
             challenge = Challenge(superblock, file)
@@ -144,5 +151,6 @@ def prebuild_command(
 
     # Copy all the locales for this language
     write_locales_to_path(locales, curriculum_dist)
+    validate_locales(curriculum_dist / "locales", included_superblocks)
     logger.info(f"Prebuilt curriculum into {curriculum_dist}")
     logger.info("Scraper: prebuild phase finished")

--- a/scraper/src/fcc2zim/ui_keys.yaml
+++ b/scraper/src/fcc2zim/ui_keys.yaml
@@ -1,0 +1,25 @@
+# Keys from locale files that the ZIM UI uses.
+# Dynamic content isn't listed here since those keys depend on which courses and superblocks are included.
+
+translations:
+  buttons:
+    check-code:
+    reset-lesson:
+    run:
+    go-to-next:
+  learn:
+    heading:
+    reset:
+    reset-warn:
+      placeholders:
+        - title
+    reset-warn-2:
+
+motivation:
+  compliment:
+
+intro:
+  misc-text:
+    courses:
+    expand:
+    collapse:

--- a/scraper/tasks.py
+++ b/scraper/tasks.py
@@ -76,6 +76,12 @@ def check_pyright(ctx: Context, args: str = ""):
     ctx.run(f"pyright {args}", pty=use_pty)
 
 
+@task
+def check_ui_keys(ctx: Context):
+    """checks that the UI code only uses translation keys that are from ui_keys.yaml"""
+    ctx.run("python -m fcc2zim.check_ui_keys", pty=use_pty)
+
+
 @task(optional=["args"], help={"args": "check tools (pyright) additional arguments"})
 def checkall(ctx: Context, args: str = ""):
     """check static types"""

--- a/zimui/src/components/CourseBlocks.vue
+++ b/zimui/src/components/CourseBlocks.vue
@@ -37,8 +37,8 @@ const completedChallengesCount = computed(() => {
 <template>
   <button @click="toggleOpen">
     <img :src="block_arrow" class="icon" :class="{ open: isOpen }" aria-hidden="true" />
-    <div v-if="isOpen">{{ main.localesIntroMiscText?.collapse }}</div>
-    <div v-else>{{ main.localesIntroMiscText?.expand }}</div>
+    <div v-if="isOpen">{{ main.t('intro.misc-text.collapse') }}</div>
+    <div v-else>{{ main.t('intro.misc-text.expand') }}</div>
     <div class="completed">
       <img
         :src="completedChallengesCount == totalChallengesCount ? checkbox_checked : checkbox_empty"

--- a/zimui/src/components/CurriculumsOverview.vue
+++ b/zimui/src/components/CurriculumsOverview.vue
@@ -10,17 +10,17 @@ import right_arrow from '../assets/right_arrow.svg'
 const main = useMainStore()
 
 const randomQuote = computed(() => {
-  return main.localesMotivation?.motivationalQuotes.random()
+  return main.getRandomQuote()
 })
 </script>
 
 <template>
   <div
     v-if="
-      main.curriculums && main.localesIntro && main.localesMotivation && main.localesTranslations
+      main.curriculums && main.isIntroReady && main.isMotivationReady && main.isTranslationsReady
     "
   >
-    <h1>{{ main.localesTranslations.learn['heading'] }}</h1>
+    <h1>{{ main.t('translations.learn.heading') }}</h1>
     <blockquote>
       <q>{{ randomQuote?.quote }}</q>
       <footer>
@@ -32,7 +32,7 @@ const randomQuote = computed(() => {
         <RouterLink :to="`/${curriculum}`">
           <div class="course">
             <SuperblockIcon :superblock="curriculum" class="icon" />
-            <span>{{ main.localesIntro[curriculum].title }}</span>
+            <span>{{ main.tIntro(`${curriculum}.title`) }}</span>
             <img :src="right_arrow" aria-hidden="true" />
           </div>
         </RouterLink>

--- a/zimui/src/components/SuperblockOverview.vue
+++ b/zimui/src/components/SuperblockOverview.vue
@@ -17,17 +17,17 @@ const activeCourse = toRef(props, 'activeCourse')
 </script>
 
 <template>
-  <div class="my-2" v-if="main.localesIntro && main.localesIntroMiscText && main.curriculums">
-    <h1>{{ main.localesIntro[superblock].title }}</h1>
+  <div class="my-2" v-if="main.isIntroReady && main.isIntroMiscTextReady && main.curriculums">
+    <h1>{{ main.tIntro(`${superblock}.title`) }}</h1>
     <SuperblockIcon :superblock="superblock" class="icon" />
     <!-- eslint-disable-next-line vue/no-v-html-->
     <p
-      v-for="(p, jdx) in main.localesIntro[superblock].intro"
+      v-for="(p, jdx) in main.tIntro(`${superblock}.intro`) as string[]"
       :key="jdx"
       class="my-2 super-block-intro"
       v-html="p"
     ></p>
-    <h2>{{ main.localesIntroMiscText.courses }}</h2>
+    <h2>{{ main.t('intro.misc-text.courses') }}</h2>
     <div
       class="block-parent"
       :id="`${superblock}-${course}`"
@@ -35,14 +35,17 @@ const activeCourse = toRef(props, 'activeCourse')
       :key="course"
     >
       <div class="block">
-        <h3 class="block-header">{{ main.localesIntro[superblock].blocks[course].title }}</h3>
+        <h3 class="block-header">
+          {{ main.tIntro(`${superblock}.blocks.${course}.title`) }}
+        </h3>
         <div class="block-description">
           <p
-            v-for="(p, jdx) in main.localesIntro[superblock].blocks[course].intro"
+            v-for="(p, jdx) in main.tIntro(
+              `${superblock}.blocks.${course}.intro`
+            ) as string[]"
             :key="jdx"
             v-html="p"
           ></p>
-          {{ main.localesIntro[course] }}
         </div>
         <CourseBlocks
           :superblock="superblock"

--- a/zimui/src/components/challenge/ChallengeBreadcrumbs.vue
+++ b/zimui/src/components/challenge/ChallengeBreadcrumbs.vue
@@ -16,11 +16,11 @@ const course = computed(() => singlePathParam(route.params.course))
     <nav>
       <ol>
         <li class="breadcrumb-left">
-          <RouterLink to="/">{{ main.localesIntro?.[superblock].title }} </RouterLink>
+          <RouterLink to="/">{{ main.tIntro(`${superblock}.title`) }} </RouterLink>
         </li>
         <li class="breadcrumb-right">
           <RouterLink :to="`/${superblock}/${course}`">
-            {{ main.localesIntro?.[superblock].blocks[course].title }}
+            {{ main.tIntro(`${superblock}.blocks.${course}.title`) }}
           </RouterLink>
         </li>
       </ol>

--- a/zimui/src/components/challenge/ChallengeDesktop.vue
+++ b/zimui/src/components/challenge/ChallengeDesktop.vue
@@ -24,21 +24,18 @@ function checkCode() {
   <Splitpanes>
     <Pane class="left">
       <ChallengeInstructions />
-      <div class="buttons" v-if="main.localesTranslations">
+      <div class="buttons" v-if="main.isTranslationsReady">
         <!--Cheat button (dev-only)-->
         <button v-if="main.cheatMode" @click="main.cheatSolution()">Set solution</button>
 
         <!--Run the tests button-->
-        <button
-          :class="{ 'tests-failed-flash': main.testsFlash }"
-          @click="checkCode"
-        >
-          {{ main.localesTranslations.buttons['check-code'] }}
+        <button :class="{ 'tests-failed-flash': main.testsFlash }" @click="checkCode">
+          {{ main.t('translations.buttons.check-code') }}
         </button>
 
         <!--Reset code-->
         <button @click="main.challengeResetDialogActive = true">
-          {{ main.localesTranslations.buttons['reset-lesson'] }}
+          {{ main.t('translations.buttons.reset-lesson') }}
         </button>
 
         <ChallengeDialogs />

--- a/zimui/src/components/challenge/ChallengeDialogs.vue
+++ b/zimui/src/components/challenge/ChallengeDialogs.vue
@@ -4,7 +4,6 @@ import type { ComputedRef } from 'vue'
 import { computed } from 'vue'
 import type { ChallengeInfo } from '@/types/challenges'
 import { singlePathParam } from '@/utils/pathParams'
-import { interpolate } from '@/utils/interpolate'
 import { useRoute, useRouter } from 'vue-router'
 
 import test_passed from '@/assets/test_passed.svg'
@@ -21,27 +20,26 @@ const nextChallenge: ComputedRef<ChallengeInfo | undefined> = computed(() => {
   return main.nextChallenge(superblock.value, course.value, slug.value)
 })
 
-const randomCompliment: ComputedRef<string | undefined> = computed(() =>
-  main.localesMotivation?.compliments.random()
-)
+const randomCompliment = computed(() => main.t('motivation.compliment'))
 
 const resetWarnMessage = computed(() => {
-  const msg = main.localesTranslations?.learn['reset-warn'] || ''
-  return interpolate(msg, { title: main.challenge?.header['title'] || '' })
+  return main.t('translations.learn.reset-warn', {
+    title: main.challenge?.header['title'] || ''
+  })
 })
 </script>
 
 <template>
   <!--Reset dialog-->
   <v-dialog
-    v-if="main.localesTranslations"
+    v-if="main.isTranslationsReady"
     v-model="main.challengeResetDialogActive"
     max-width="500"
   >
     <template v-slot:default>
       <v-sheet class="danger">
         <div class="header">
-          <h2>{{ main.localesTranslations.learn['reset'] }}</h2>
+          <h2>{{ main.t('translations.learn.reset') }}</h2>
           <button class="close" type="button" @click="main.challengeResetDialogActive = false">
             <span class="sr-only">Close</span>
             <span aria-hidden="true">×</span>
@@ -50,7 +48,7 @@ const resetWarnMessage = computed(() => {
         <div class="message">
           <p>{{ resetWarnMessage }}</p>
           <p>
-            <em>{{ main.localesTranslations.learn['reset-warn-2'] }}</em>
+            <em>{{ main.t('translations.learn.reset-warn-2') }}</em>
           </p>
         </div>
         <div>
@@ -65,7 +63,7 @@ const resetWarnMessage = computed(() => {
               }
             "
           >
-            {{ main.localesTranslations.buttons['reset-lesson'] }}
+            {{ main.t('translations.buttons.reset-lesson') }}
           </button>
         </div>
       </v-sheet>
@@ -74,7 +72,7 @@ const resetWarnMessage = computed(() => {
 
   <!--Passed dialog-->
   <v-dialog
-    v-if="main.localesTranslations"
+    v-if="main.isTranslationsReady"
     v-model="main.challengePassedDialogActive"
     max-width="700"
   >
@@ -106,7 +104,7 @@ const resetWarnMessage = computed(() => {
               }
             "
           >
-            {{ main.localesTranslations.buttons['go-to-next'] }}
+            {{ main.t('translations.buttons.go-to-next') }}
           </button>
         </div>
       </v-sheet>

--- a/zimui/src/components/challenge/ChallengeMobile.vue
+++ b/zimui/src/components/challenge/ChallengeMobile.vue
@@ -30,7 +30,7 @@ function checkCode() {
 </script>
 
 <template>
-  <div v-if="main.localesTranslations" class="main">
+  <div v-if="main.isTranslationsReady" class="main">
     <div class="header">
       <button
         :class="{ active: selectedTab === MobileTab.Instructions }"
@@ -66,13 +66,10 @@ function checkCode() {
     <div class="footer">
       <button v-if="main.cheatMode" @click="main.cheatSolution()">Set solution</button>
       <button @click="main.challengeResetDialogActive = true">
-        {{ main.localesTranslations.buttons['reset-lesson'] }}
+        {{ main.t('translations.buttons.reset-lesson') }}
       </button>
-      <button
-        :class="{ 'tests-failed-flash': main.testsFlash}"
-        @click="checkCode"
-      >
-        {{ main.localesTranslations.buttons['run'] }}
+      <button :class="{ 'tests-failed-flash': main.testsFlash }" @click="checkCode">
+        {{ main.t('translations.buttons.run') }}
       </button>
 
       <ChallengeDialogs />

--- a/zimui/src/pages/ChallengePage.vue
+++ b/zimui/src/pages/ChallengePage.vue
@@ -30,7 +30,7 @@ watch(
 
 <template>
   <div class="page" v-if="main.isLoading">Page is loading ...</div>
-  <div class="page" v-else-if="main.challenge && main.localesIntro">
+  <div class="page" v-else-if="main.challenge && main.isIntroReady">
     <ChallengeBreadcrumbs />
     <div
       v-if="supportedChallengeTypes.includes(main.challenge.header['challengeType'])"

--- a/zimui/src/pages/HomePage.vue
+++ b/zimui/src/pages/HomePage.vue
@@ -8,7 +8,7 @@ const main = useMainStore()
 </script>
 
 <template>
-  <div class="main" v-if="main.curriculums && main.localesIntro && main.localesIntroMiscText">
+  <div class="main" v-if="main.curriculums && main.isIntroReady && main.isIntroMiscTextReady">
     <CurriculumsOverview v-if="Object.keys(main.curriculums).length > 1" />
     <SuperblockOverview :superblock="Object.keys(main.curriculums)[0]" v-else />
   </div>

--- a/zimui/src/pages/SuperblockPage.vue
+++ b/zimui/src/pages/SuperblockPage.vue
@@ -32,7 +32,7 @@ watch(
 </script>
 
 <template>
-  <div class="main" v-if="main.localesIntro && main.localesIntroMiscText && main.curriculums">
+  <div class="main" v-if="main.isIntroReady && main.isIntroMiscTextReady && main.curriculums">
     <SuperblockOverview :superblock="superblock" :activeCourse="course" />
   </div>
   <div class="main" v-else-if="main.isLoading">Page is loading ...</div>

--- a/zimui/src/stores/main.ts
+++ b/zimui/src/stores/main.ts
@@ -12,12 +12,13 @@ import type { Challenge } from '@/utils/parseChallenge'
 import mathjaxService from '@/services/mathjax'
 import type { RunResult, RunResultHint } from '@/utils/runChallenge'
 import { runChallenge } from '@/utils/runChallenge'
+import { interpolate } from '@/utils/interpolate'
 
 export type RootState = {
-  localesIntro: LocalesIntro | null
-  localesIntroMiscText: LocalesIntroMiscText | null
-  localesMotivation: LocalesMotivation | null
-  localesTranslations: LocalesTranslations | null
+  _localesIntro: LocalesIntro | null
+  _localesIntroMiscText: LocalesIntroMiscText | null
+  _localesMotivation: LocalesMotivation | null
+  _localesTranslations: LocalesTranslations | null
   curriculums: Curriculums | null
   challenge: Challenge | null
   solution: string
@@ -63,13 +64,14 @@ const runTest = function (state: any) {
   }
 }
 
-export const useMainStore = defineStore('main', {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const _useMainStore: any = defineStore('main', {
   state: () =>
     ({
-      localesIntro: null,
-      localesIntroMiscText: null,
-      localesMotivation: null,
-      localesTranslations: null,
+      _localesIntro: null,
+      _localesIntroMiscText: null,
+      _localesMotivation: null,
+      _localesTranslations: null,
       curriculums: null,
       challenge: null,
       solution: '',
@@ -83,6 +85,10 @@ export const useMainStore = defineStore('main', {
       testsFlash: false
     }) as RootState,
   getters: {
+    isIntroReady: (state) => state._localesIntro !== null,
+    isIntroMiscTextReady: (state) => state._localesIntroMiscText !== null,
+    isMotivationReady: (state) => state._localesMotivation !== null,
+    isTranslationsReady: (state) => state._localesTranslations !== null,
     nextChallenge: nextChallenge,
     runTest: runTest
   },
@@ -95,12 +101,12 @@ export const useMainStore = defineStore('main', {
       return axios.get('./content/locales/intro.json').then(
         (response) => {
           this.isLoading = false
-          this.localesIntro = response.data as LocalesIntro
-          this.localesIntroMiscText = response.data['misc-text'] as LocalesIntroMiscText
+          this._localesIntro = response.data as LocalesIntro
+          this._localesIntroMiscText = response.data['misc-text'] as LocalesIntroMiscText
         },
         (error) => {
           this.isLoading = false
-          this.localesIntro = null
+          this._localesIntro = null
           this.errorMessage = 'Failed to load locales intro.json data.'
           if (error instanceof AxiosError) {
             this.handleAxiosError(error)
@@ -116,11 +122,11 @@ export const useMainStore = defineStore('main', {
       return axios.get('./content/locales/motivation.json').then(
         (response) => {
           this.isLoading = false
-          this.localesMotivation = response.data as LocalesMotivation
+          this._localesMotivation = response.data as LocalesMotivation
         },
         (error) => {
           this.isLoading = false
-          this.localesMotivation = null
+          this._localesMotivation = null
           this.errorMessage = 'Failed to load locales motivation.json data.'
           if (error instanceof AxiosError) {
             this.handleAxiosError(error)
@@ -136,11 +142,11 @@ export const useMainStore = defineStore('main', {
       return axios.get('./content/locales/translations.json').then(
         (response) => {
           this.isLoading = false
-          this.localesTranslations = response.data as LocalesTranslations
+          this._localesTranslations = response.data as LocalesTranslations
         },
         (error) => {
           this.isLoading = false
-          this.localesTranslations = null
+          this._localesTranslations = null
           this.errorMessage = 'Failed to load locales translations.json data.'
           if (error instanceof AxiosError) {
             this.handleAxiosError(error)
@@ -160,7 +166,7 @@ export const useMainStore = defineStore('main', {
         },
         (error) => {
           this.isLoading = false
-          this.localesIntro = null
+          this._localesIntro = null
           this.errorMessage = 'Failed to load curriculum/index.json data.'
           if (error instanceof AxiosError) {
             this.handleAxiosError(error)
@@ -220,6 +226,41 @@ export const useMainStore = defineStore('main', {
     },
     cheatSolution() {
       this.solution = this.challenge?.solutions[0] || ''
+    },
+    tIntro(key: string): string | string[] {
+      if (!this._localesIntro) return ''
+      const parts = key.split('.')
+      const sbData = this._localesIntro[parts[0]]
+      if (!sbData) return ''
+      if (parts.length === 2) return sbData[parts[1] as 'title' | 'intro'] ?? ''
+      if (parts.length === 4 && parts[1] === 'blocks')
+        return sbData.blocks?.[parts[2]]?.[parts[3] as 'title' | 'intro'] ?? ''
+      return ''
+    },
+    getRandomQuote(): { quote: string; author: string } | undefined {
+      return this._localesMotivation?.motivationalQuotes.random()
+    },
+    t(key: string, vars?: Record<string, string>): string {
+      const [file, section, name] = key.split('.')
+      let value: string | undefined
+
+      if (file === 'translations') {
+        value = (this._localesTranslations as Record<string, Record<string, string>> | null)?.[
+          section
+        ]?.[name]
+      } else if (file === 'intro' && section === 'misc-text') {
+        value = (this._localesIntroMiscText as Record<string, string> | null)?.[name]
+      } else if (file === 'motivation' && section === 'compliment') {
+        value = this._localesMotivation?.compliments.random()
+      }
+
+      if (!value) return ''
+      return vars ? interpolate(value, vars) : value
     }
   }
 })
+
+// re-export via function to avoid TS7056 (composite declaration emit limit)
+export function useMainStore() {
+  return _useMainStore()
+}


### PR DESCRIPTION
Closes #142

- Added a YAML file defining which locale keys the UI uses and their expected placeholders
- Added scrape time validation that checks locale files against the YAML and fails the build if anything seems off
- Added a CI check that scans UI code for translation keys not listed in the YAML
- Centralized all static translation lookups into a `t()` function in the main store