### PR TITLE
resolves #144: Zim UI inside pip package

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -13,6 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: zimui/.node-version
+
+      - name: Build zimui
+        working-directory: zimui
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -99,3 +99,7 @@ jobs:
       - name: Ensure we can start the Docker image
         run: |
           docker run --rm testimage fcc2zim --version
+      
+      - name: Ensure zimui and its dependencies are included in the Docker image
+        run: |
+          docker run --rm testimage python -c "from pathlib import Path; import fcc2zim; path = Path(fcc2zim.__file__).parent / 'zimui'; assert (path / 'index.html').is_file() and (path / 'assets').is_dir(), 'zimui not found'"

--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,4 @@ zimui/public/content
 zimui/public/mathjax
 scraper/src/fcc2zim/mathjax
 scraper/src/fcc2zim/fonts
+scraper/src/fcc2zim/zimui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix interpolation for placeholders in translation strings (#139)
 - Fix prettier and eslint check in zimui QA CI.(#146)
+- Bundled ZIM UI inside pip package (#144)
 
 ## [2.0.3] - 2025-11-25
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:24-alpine AS zimui
 
 WORKDIR /src
-COPY zimui /src
+COPY zimui /src/zimui
+WORKDIR /src/zimui
 RUN yarn install --frozen-lockfile
 RUN yarn build
 
@@ -12,11 +13,13 @@ LABEL org.opencontainers.image.source=https://github.com/openzim/freecodecamp
 RUN python -m pip install --no-cache-dir -U \
       pip
 
-# Copy code + associated artifacts + zimui build output
+# Copy code + associated artifacts
 COPY LICENSE LICENSE.fcc.md README.md /src/
 COPY scraper/pyproject.toml scraper/openzim.toml scraper/tasks.py /src/scraper/
 COPY scraper/src /src/scraper/src
-COPY --from=zimui /src/dist /src/zimui
+
+# Copy zimui build output
+COPY --from=zimui /src/scraper/src/fcc2zim/zimui /src/scraper/src/fcc2zim/zimui
 
 # Install + cleanup
 RUN pip install --no-cache-dir /src/scraper \
@@ -28,6 +31,5 @@ WORKDIR /output
 
 ENV FCC_BUILD=/tmp
 ENV FCC_OUTPUT=/output
-ENV FCC_ZIMUI_DIST=/src/zimui
 
 CMD ["fcc2zim", "--help"]

--- a/scraper/pyproject.toml
+++ b/scraper/pyproject.toml
@@ -90,7 +90,7 @@ all = "inv checkall --args '{args}'"
 [tool.black]
 line-length = 88
 target-version = ['py314']
-exclude = "(.hatch/.*)"
+exclude = "(src/fcc2zim/zimui/.*|.hatch/.*)"
 
 [tool.ruff]
 target-version = "py314"
@@ -212,7 +212,7 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.pyright]
 include = ["src", "tests", "tasks.py"]
-exclude = [".env/**", ".venv/**", ".hatch"]
+exclude = [".env/**", ".venv/**", "src/fcc2zim/zimui", ".hatch"]
 extraPaths = ["src"]
 pythonVersion = "3.14"
 typeCheckingMode = "strict"

--- a/scraper/src/fcc2zim/context.py
+++ b/scraper/src/fcc2zim/context.py
@@ -58,7 +58,9 @@ class Context:
     build_folder: Path = Path(os.getenv("FCC_BUILD", "../build"))
 
     # folder where Vue.JS UI has been built
-    zimui_dist: Path = Path(os.getenv("FCC_ZIMUI_DIST", "../zimui/dist"))
+    zimui_dist: Path = Path(
+        os.getenv("FCC_ZIMUI_DIST", str(Path(__file__).parent / "zimui"))
+    )
 
     # ZIP of FCC content
     main_zip_path: Path | None = None

--- a/zimui/vite.config.ts
+++ b/zimui/vite.config.ts
@@ -9,6 +9,8 @@ import { writeFileSync, existsSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { parse } from 'node-html-parser'
 
+const buildOutputDir = '../scraper/src/fcc2zim/zimui'
+
 /**
  * Rewrites HTML code by extracting inline JS code to plain files, keeping the rest
  * intact.
@@ -62,7 +64,7 @@ export default defineConfig({
       apply: 'build',
       enforce: 'post',
       transformIndexHtml(html) {
-        return extractInlineJS(html)
+        return extractInlineJS(html, buildOutputDir)
       }
     }
   ],
@@ -70,5 +72,9 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  build: {
+    outDir: buildOutputDir,
+    emptyOutDir: true
   }
 })


### PR DESCRIPTION
Fixes #144 
- copies zimui, and bundles it inside scrapper.
- note: `zimui/src/components/challenge/ChallengeMobile.vue`, `zimui/src/components/challenge/ChallengeMobile.vue`, `zimui/src/components/challenge/CodeEditor.vue` and `zimui/src/style.css` was formatted when `yarn format`.
