### PR TITLE
rename length constraints to graphemes

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -69,24 +69,24 @@
       "required": true,
       "title": "Title",
       "description": "ZIM title",
-      "minLength": 1,
-      "maxLength": 30
+      "minGraphemes": 1,
+      "maxGraphemes": 30
     },
     "description": {
       "type": "string",
       "required": true,
       "title": "Description",
       "description": "ZIM description",
-      "minLength": 1,
-      "maxLength": 80
+      "minGraphemes": 1,
+      "maxGraphemes": 80
     },
     "long_description": {
       "type": "string",
       "required": false,
       "title": "Long description",
       "description": "ZIM long description",
-      "minLength": 1,
-      "maxLength": 4000
+      "minGraphemes": 1,
+      "maxGraphemes": 4000
     },
     "creator": {
       "type": "string",


### PR DESCRIPTION
## Changes
- rename length constraints to end with graphemes (See openzim/zimfarm#1890)